### PR TITLE
Fix proxy unwrap breaking when using pure python proxy implementation.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix proxy unwrap breaking when using pure python proxy implementation.
 
 
 1.0.0 (2017-04-17)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ CHANGES
 ------------------
 
 - Fix proxy unwrap breaking when using pure python proxy implementation.
+  (`#2 <https://github.com/zopefoundation/z3c.menu.ready2go/pull/2>`_)
 
 
 1.0.0 (2017-04-17)

--- a/src/z3c/menu/ready2go/item.py
+++ b/src/z3c/menu/ready2go/item.py
@@ -14,7 +14,7 @@
 """Menu Item
 """
 import zope.interface
-import zope.proxy
+import zope.security.proxy
 from zope.traversing.api import getRoot
 from zope.traversing.browser import absoluteURL
 
@@ -134,8 +134,8 @@ class SiteMenuItem(MenuItem):
     @property
     def available(self):
         """Available checker call"""
-        root = zope.proxy.getProxiedObject(getRoot(self.context))
-        site = zope.proxy.getProxiedObject(hooks.getSite())
+        root = zope.security.proxy.getObject(getRoot(self.context))
+        site = zope.security.proxy.getObject(hooks.getSite())
         return site is not root
 
     def getURLContext(self):


### PR DESCRIPTION
Typical error message: `ForbiddenAttribute: ('_wrapped', <zope.site.folder.Folder object at 0x10d2da4b0>)`